### PR TITLE
Return 201 by default for ProvisionResponse and BindResponse.

### DIFF
--- a/cf-spring/src/main/java/cf/spring/servicebroker/BindResponse.java
+++ b/cf-spring/src/main/java/cf/spring/servicebroker/BindResponse.java
@@ -19,9 +19,13 @@ package cf.spring.servicebroker;
 import cf.common.JsonObject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * The response returned to the Cloud Controller after a successful bind. Methods annotated with {@code @Bind} must
- * return an instance of this type.
+ * return an instance of this type. This is to be used when a successful binding occurs as the Cloud Controller
+ * expects a 201 status code. When the exact same request has already been made previously, one should use
+ * {@link BindResponseIdentical} instead, to be able to return a 200 status code to the Cloud Controller
  *
  * @author Mike Heath <elcapo@gmail.com>
  */
@@ -63,5 +67,9 @@ public class BindResponse extends JsonObject {
 	@JsonProperty("syslog_drain_url")
 	public String getSyslogDrainUrl() {
 		return syslogDrainUrl;
+	}
+
+	public int getHttpStatusCode() {
+		return HttpServletResponse.SC_CREATED;
 	}
 }

--- a/cf-spring/src/main/java/cf/spring/servicebroker/BindResponseIdentical.java
+++ b/cf-spring/src/main/java/cf/spring/servicebroker/BindResponseIdentical.java
@@ -1,0 +1,26 @@
+package cf.spring.servicebroker;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * {@link BindResponse} subclass, intended to easily be able to return a 200 status code to the Cloud Controller
+ * when the bind request currently processed is the exact same as one before. Response body must of course be the
+ * same as the previous one. Although not mandatory, this can help having a more robust service broker,
+ * by being able to handle idempotent requests without treating them as conflicts.
+ *
+ * @author Thomas Demande
+ */
+public class BindResponseIdentical extends BindResponse {
+    public BindResponseIdentical(Object credentials) {
+        super(credentials);
+    }
+
+    public BindResponseIdentical(Object credentials, String syslogDrainUrl) {
+        super(credentials, syslogDrainUrl);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpServletResponse.SC_OK;
+    }
+}

--- a/cf-spring/src/main/java/cf/spring/servicebroker/ProvisionResponse.java
+++ b/cf-spring/src/main/java/cf/spring/servicebroker/ProvisionResponse.java
@@ -20,8 +20,14 @@ import cf.common.JsonObject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * The response returned to the Cloud Controller after a service has been successfully provisioned.
+ * This is to be used when a successful provision occurs as the Cloud Controller expects a 201 status code.
+ * When the exact same request has already been made previously, one should use
+ * {@link cf.spring.servicebroker.ProvisionResponseIdentical} instead, to be able to instead
+ * return a 200 status code to the Cloud Controller
  *
  * @author Mike Heath <elcapo@gmail.com>
  */
@@ -45,5 +51,9 @@ public class ProvisionResponse extends JsonObject {
 	@JsonProperty(DASHBOARD_URL_PROPERTY)
 	public String getDashboardUrl() {
 		return dashboardUrl;
+	}
+
+	public int getHttpStatusCode() {
+		return HttpServletResponse.SC_CREATED;
 	}
 }

--- a/cf-spring/src/main/java/cf/spring/servicebroker/ProvisionResponseIdentical.java
+++ b/cf-spring/src/main/java/cf/spring/servicebroker/ProvisionResponseIdentical.java
@@ -1,0 +1,27 @@
+package cf.spring.servicebroker;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * {@link ProvisionResponse} subclass, intended to easily be able to return a 200 status code to the Cloud Controller
+ * when the provision request currently processed is the exact same as one before. Response body must of course be the
+ * same as the previous one. Although not mandatory, this can help having a more robust service broker,
+ * by being able to handle idempotent requests without treating them as conflicts.
+ *
+ * @author Thomas Demande
+ */
+public class ProvisionResponseIdentical extends ProvisionResponse {
+    public ProvisionResponseIdentical() {
+    }
+
+    public ProvisionResponseIdentical(@JsonProperty(DASHBOARD_URL_PROPERTY) String dashboardUrl) {
+        super(dashboardUrl);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpServletResponse.SC_OK;
+    }
+}

--- a/cf-spring/src/main/java/cf/spring/servicebroker/ServiceBrokerHandler.java
+++ b/cf-spring/src/main/java/cf/spring/servicebroker/ServiceBrokerHandler.java
@@ -80,7 +80,8 @@ public class ServiceBrokerHandler implements HttpRequestHandler {
 							provisionBody.getPlanId(),
 							provisionBody.getOrganizationGuid(),
 							provisionBody.getSpaceGuid());
-					final Object provisionResponse = accessor.provision(provisionRequest);
+					final ProvisionResponse provisionResponse = accessor.provision(provisionRequest);
+					response.setStatus(provisionResponse.getHttpStatusCode());
 					mapper.writeValue(response.getOutputStream(), provisionResponse);
 				} else {
 					final BindBody bindBody = mapper.readValue(request.getInputStream(), BindBody.class);
@@ -92,7 +93,8 @@ public class ServiceBrokerHandler implements HttpRequestHandler {
 							UUID.fromString(bindingId),
 							bindBody.applicationGuid,
 							bindBody.getPlanId());
-					final Object bindResponse = accessor.bind(bindRequest);
+					final BindResponse bindResponse = accessor.bind(bindRequest);
+					response.setStatus(bindResponse.getHttpStatusCode());
 					mapper.writeValue(response.getOutputStream(), bindResponse);
 				}
 			} else if ("delete".equalsIgnoreCase(request.getMethod())) {

--- a/cf-spring/src/test/java/cf/spring/CfComponentTest.java
+++ b/cf-spring/src/test/java/cf/spring/CfComponentTest.java
@@ -123,7 +123,7 @@ public class CfComponentTest {
 			HttpClient client = HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build();
 			HttpGet get = new HttpGet("http://" + natsAnnouncement.getHost() + "/varz");
 			final HttpResponse response = client.execute(get);
-			assertEquals(200, response.getStatusLine().getStatusCode());
+			assertEquals(response.getStatusLine().getStatusCode(), 200);
 			final JsonNode node = new ObjectMapper().readTree(response.getEntity().getContent());
 			assertEquals(node.get("type").asText(), "Test");
 			assertEquals(node.get("index").asInt(), componentConfiguration.getIndex());
@@ -160,7 +160,7 @@ public class CfComponentTest {
 			HttpClient client = HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build();
 			HttpGet get = new HttpGet("http://" + natsAnnouncement.getHost() + "/varz");
 			final HttpResponse response = client.execute(get);
-			assertEquals(200, response.getStatusLine().getStatusCode());
+			assertEquals(response.getStatusLine().getStatusCode(), 200);
 			final JsonNode node = new ObjectMapper().readTree(response.getEntity().getContent());
 			assertEquals(node.get("type").asText(), "Test");
 			assertEquals(node.get("test").asText(), "value");

--- a/cf-spring/src/test/java/cf/spring/servicebroker/ServiceBrokerTest.java
+++ b/cf-spring/src/test/java/cf/spring/servicebroker/ServiceBrokerTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
@@ -207,7 +208,7 @@ public class ServiceBrokerTest extends AbstractServiceBrokerTest {
 				.setEntity(new StringEntity(mapper.writeValueAsString(bindBody), ContentType.APPLICATION_JSON))
 				.build();
 		final CloseableHttpResponse bindResponse = client.execute(bindRequest);
-		assertEquals(bindResponse.getStatusLine().getStatusCode(), 200);
+		assertEquals(bindResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED);
 		assertEquals(bindCounter.get(), 1);
 		final JsonNode bindResponseJson = mapper.readTree(bindResponse.getEntity().getContent());
 		assertTrue(bindResponseJson.has("credentials"));
@@ -227,7 +228,7 @@ public class ServiceBrokerTest extends AbstractServiceBrokerTest {
 				.setUri(bindingUri + "?service_id=" + BROKER_ID_STATIC + "&" + "plan_id=" + PLAN_ID)
 				.build();
 		final CloseableHttpResponse unbindResponse = client.execute(unbindRequest);
-		assertEquals(unbindResponse.getStatusLine().getStatusCode(), 200);
+		assertEquals(unbindResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
 		assertEquals(unbindCounter.get(), 1);
 	}
 
@@ -242,7 +243,7 @@ public class ServiceBrokerTest extends AbstractServiceBrokerTest {
 				.setUri(instanceUri + "?service_id=" + BROKER_ID_STATIC + "&" + "plan_id=" + PLAN_ID)
 				.build();
 		final CloseableHttpResponse deprovisionResponse = client.execute(deprovisionRequest);
-		assertEquals(deprovisionResponse.getStatusLine().getStatusCode(), 200);
+		assertEquals(deprovisionResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
 		assertEquals(deprovisionCounter.get(), 1);
 	}
 
@@ -254,7 +255,7 @@ public class ServiceBrokerTest extends AbstractServiceBrokerTest {
 				.setEntity(new StringEntity(mapper.writeValueAsString(provisionBody), ContentType.APPLICATION_JSON))
 				.build();
 		final CloseableHttpResponse provisionResponse = client.execute(provisionRequest);
-		assertEquals(provisionResponse.getStatusLine().getStatusCode(), 404);
+		assertEquals(provisionResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_NOT_FOUND);
 		final JsonNode errorJson = mapper.readTree(provisionResponse.getEntity().getContent());
 		assertTrue(errorJson.has("description"));
 	}
@@ -269,7 +270,7 @@ public class ServiceBrokerTest extends AbstractServiceBrokerTest {
 			  .setEntity(new StringEntity(mapper.writeValueAsString(provisionBody), ContentType.APPLICATION_JSON))
 			  .build();
 		final CloseableHttpResponse provisionResponse = client.execute(provisionRequest);
-		assertEquals(provisionResponse.getStatusLine().getStatusCode(), 200);
+		assertEquals(provisionResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED);
 		assertEquals(provisionCounter.get(), 1);
 
 		final JsonNode provisionResponseJson = mapper.readTree(provisionResponse.getEntity().getContent());


### PR DESCRIPTION
Also adds the capacity to return 200 by using subclasses of these responses.
Better variant than the previous https://github.com/cloudfoundry-community/cf-java-component/pull/5
